### PR TITLE
Implement Notes List Display in NotesView and Refactor NotesService StreamController

### DIFF
--- a/lib/services/crud/notes_service.dart
+++ b/lib/services/crud/notes_service.dart
@@ -24,11 +24,16 @@ class NotesService {
   }
 
   List<DatabaseNote> _notes = [];
-  final _noteStreamController =
-      StreamController<List<DatabaseNote>>.broadcast();
+  late final StreamController<List<DatabaseNote>> _noteStreamController;
 
   static final NotesService _shared = NotesService._sharedInstance();
-  NotesService._sharedInstance();
+  NotesService._sharedInstance() {
+    _noteStreamController = StreamController<List<DatabaseNote>>.broadcast(
+      onListen: () {
+        _noteStreamController.sink.add(_notes);
+      },
+    );
+  }
   factory NotesService() => _shared;
   Stream<List<DatabaseNote>> get allNotes => _noteStreamController.stream;
   Future<void> _cacheNotes() async {

--- a/lib/views/notes/notes_view.dart
+++ b/lib/views/notes/notes_view.dart
@@ -23,12 +23,6 @@ class _NotesViewState extends State<NotesView> {
   }
 
   @override
-  void dispose() {
-    _notesService.close();
-    super.dispose();
-  }
-
-  @override
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
@@ -76,7 +70,26 @@ class _NotesViewState extends State<NotesView> {
                   switch (snapshot.connectionState) {
                     case ConnectionState.waiting:
                     case ConnectionState.active:
-                      return const Text('Waiting for all notes...');
+                      if (snapshot.hasData) {
+                        final allNotes = snapshot.data as List<DatabaseNote>;
+                        return ListView.builder(
+                          itemCount: allNotes.length,
+                          itemBuilder: (context, index) {
+                            final note = allNotes[index];
+                            return ListTile(
+                              title: Text(
+                                note.text,
+                                maxLines: 1,
+                                overflow: TextOverflow.ellipsis,
+                              ),
+                            );
+                          },
+                        );
+                      } else {
+                        return const Center(
+                          child: CircularProgressIndicator(),
+                        );
+                      }
                     default:
                       return const CircularProgressIndicator();
                   }


### PR DESCRIPTION
This pull request introduces the functionality to display the list of notes in the `NotesView` and includes necessary adjustments to the `NotesService` for efficient note streaming.

## Changes:

### 1. `lib/services/crud/notes_service.dart`:

* Refactored the `NotesService` to initialize the `_noteStreamController` in the constructor.
* Added an `onListen` callback to immediately stream the current list of notes (`_notes`) when a new listener subscribes.
* Ensured the stream remains broadcasted to support multiple subscribers.

### 2. `lib/views/notes/notes_view.dart`:

* Updated the notes display logic in `NotesView` to show a list of notes fetched from the database.
* Utilized `ListView.builder` to render the note titles, with a single-line preview of each note's content.
* Added handling for both the loading state (via `CircularProgressIndicator`) and the case where notes are successfully fetched.

##

These changes improve the user experience by ensuring real-time updates of the notes list and immediate streaming of data when available.