### PR TITLE
Refactor Notes Management to Use Firestore Instead of SQLite

### DIFF
--- a/lib/services/auth/auth_user.dart
+++ b/lib/services/auth/auth_user.dart
@@ -3,15 +3,18 @@ import 'package:flutter/foundation.dart';
 
 @immutable
 class AuthUser {
-  final String? email;
+  final String id;
+  final String email;
   final bool isEmailVerified;
   const AuthUser({
+    required this.id,
     required this.email,
     required this.isEmailVerified,
   });
 
   factory AuthUser.fromFirebase(User user) => AuthUser(
-        email: user.email,
+        id: user.uid,
+        email: user.email!,
         isEmailVerified: user.emailVerified,
       );
 }

--- a/lib/services/cloud/cloud_note.dart
+++ b/lib/services/cloud/cloud_note.dart
@@ -1,0 +1,21 @@
+import 'package:flutter/foundation.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:mynotes/services/cloud/cloud_storage_constants.dart';
+
+@immutable
+class CloudNote {
+  final String documentId;
+  final String ownerUserId;
+  final String text;
+
+  const CloudNote({
+    required this.documentId,
+    required this.ownerUserId,
+    required this.text,
+  });
+
+  CloudNote.fromSnapshot(QueryDocumentSnapshot<Map<String, dynamic>> snapshot)
+      : documentId = snapshot.id,
+        ownerUserId = snapshot.data()[ownerUserIdFieldName] as String,
+        text = snapshot.data()[textFieldName] as String;
+}

--- a/lib/services/cloud/cloud_storage_constants.dart
+++ b/lib/services/cloud/cloud_storage_constants.dart
@@ -1,0 +1,2 @@
+const ownerUserIdFieldName = 'user_id';
+const textFieldName = 'text';

--- a/lib/services/cloud/cloud_storage_exceptions.dart
+++ b/lib/services/cloud/cloud_storage_exceptions.dart
@@ -1,0 +1,15 @@
+class CloudStorageExceptions implements Exception {
+  const CloudStorageExceptions();
+}
+
+// C in CRUD
+class CouldNotCreateNoteException extends CloudStorageExceptions {}
+
+// R in CRUD
+class CouldNotGetAllNotesException extends CloudStorageExceptions {}
+
+// U in CRUD
+class CouldNotUpdateNoteException extends CloudStorageExceptions {}
+
+// D in CRUD
+class CouldNotDeleteNoteException extends CloudStorageExceptions {}

--- a/lib/services/cloud/firebase_cloud_storage.dart
+++ b/lib/services/cloud/firebase_cloud_storage.dart
@@ -1,0 +1,65 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:mynotes/services/cloud/cloud_note.dart';
+import 'package:mynotes/services/cloud/cloud_storage_constants.dart';
+import 'package:mynotes/services/cloud/cloud_storage_exceptions.dart';
+
+class FirebaseCloudStorage {
+  final notes = FirebaseFirestore.instance.collection('notes');
+
+  Future<void> deleteNote({required String documentId}) async {
+    try {
+      await notes.doc(documentId).delete();
+    } catch (e) {
+      throw CouldNotDeleteNoteException();
+    }
+  }
+
+  Future<void> updateNote({
+    required String documentId,
+    required String text,
+  }) async {
+    try {
+      await notes.doc(documentId).update({textFieldName: text});
+    } catch (e) {
+      throw CouldNotUpdateNoteException();
+    }
+  }
+
+  Stream<Iterable<CloudNote>> allNotes({required String ownerUserId}) =>
+      notes.snapshots().map((event) => event.docs
+          .map((doc) => CloudNote.fromSnapshot(doc))
+          .where((note) => note.ownerUserId == ownerUserId));
+
+  Future<Iterable<CloudNote>> getNotes({required String ownerUserId}) async {
+    try {
+      return await notes
+          .where(
+            ownerUserIdFieldName,
+            isEqualTo: ownerUserId,
+          )
+          .get()
+          .then((value) => value.docs.map((doc) {
+                return CloudNote(
+                  documentId: doc.id,
+                  ownerUserId: doc.data()[ownerUserIdFieldName] as String,
+                  text: doc.data()[textFieldName] as String,
+                );
+              }));
+    } catch (e) {
+      throw CouldNotGetAllNotesException();
+    }
+  }
+
+  void createNewNote({required String ownerUserId}) async {
+    await notes.add({
+      ownerUserIdFieldName: ownerUserId,
+      'text': '',
+    });
+  }
+
+  static final FirebaseCloudStorage _shared =
+      FirebaseCloudStorage._sharedInstance();
+  FirebaseCloudStorage._sharedInstance();
+
+  factory FirebaseCloudStorage() => _shared;
+}

--- a/lib/views/notes/create_update_note_view.dart
+++ b/lib/views/notes/create_update_note_view.dart
@@ -51,7 +51,7 @@ class _CreateUpdateNoteViewState extends State<CreateUpdateNoteView> {
       return existingNote;
     }
     final currentUser = AuthService.firebase().currentUser!;
-    final email = currentUser.email!;
+    final email = currentUser.email;
     final owner = await _notesService.getUser(email: email);
     final newNote = await _notesService.createNote(owner: owner);
     _note = newNote;

--- a/lib/views/notes/notes_view.dart
+++ b/lib/views/notes/notes_view.dart
@@ -15,7 +15,7 @@ class NotesView extends StatefulWidget {
 
 class _NotesViewState extends State<NotesView> {
   late final NotesService _notesService;
-  String get userEmail => AuthService.firebase().currentUser!.email!;
+  String get userEmail => AuthService.firebase().currentUser!.email;
 
   @override
   void initState() {

--- a/test/auth_test.dart
+++ b/test/auth_test.dart
@@ -107,6 +107,7 @@ class MockAuthProvider implements AuthProvider {
     if (email == 'foo@bar.com') throw InvalidCredentialsAuthException();
     if (password == 'foobar') throw InvalidCredentialsAuthException();
     const user = AuthUser(
+      id: 'my_id',
       isEmailVerified: false,
       email: '',
     );
@@ -127,7 +128,11 @@ class MockAuthProvider implements AuthProvider {
     if (!isInitialized) throw NotInitializedException();
     final user = _user;
     if (user == null) throw UserNotLoggedInAuthException();
-    const newUser = AuthUser(isEmailVerified: true, email: '');
+    const newUser = AuthUser(
+      id: 'my_id',
+      isEmailVerified: true,
+      email: '',
+    );
     _user = newUser;
   }
 }


### PR DESCRIPTION
This pull request transitions the notes management system from local SQLite storage to Firestore cloud storage, enhancing scalability and accessibility. The following changes have been made:

### Updated Auth User Model:

* Modified `auth_user.dart` to accommodate changes in user data handling with Firestore.

### Adjusted Create/Update Note View:

* Updated `create_update_note_view.dart` to reflect the new user authentication flow and ensure compatibility with Firestore.

### Modified Notes View:

* Refined `notes_view.dart` to fetch notes from Firestore based on the authenticated user.

### Auth Test Adjustments:

* Updated `auth_test.dart` to align with the new user model.

### Cloud Note Model Creation:

* Created `cloud_note.dart` to represent notes in the Firestore.

### Cloud Storage Constants:

* Introduced `cloud_storage_constants.dart` to define constant field names used in Firestore.

### Cloud Storage Exceptions:

* Established `cloud_storage_exceptions.dart` to handle potential exceptions specific to Firestore operations.

### Firebase Cloud Storage Integration:

* Developed `firebase_cloud_storage.dart` to implement CRUD operations for notes in Firestore.

## Next Steps:
* Test the integration thoroughly to ensure all features work as intended with Firestore.
* Begin updating any dependent services or components to ensure seamless functionality in the new cloud-based architecture.